### PR TITLE
EN-2590: Disable TLS v1.0 connections

### DIFF
--- a/drupal-auth-proxy.litcoffee
+++ b/drupal-auth-proxy.litcoffee
@@ -135,7 +135,8 @@ The is the function that actually forwards a request to the backend
 service.
 
     forwardRequest = (req, res) ->
-      res.header('Drupal-Auth-Proxy-Host', os.hostname())
+      if config.get('devMode')
+        res.header('Drupal-Auth-Proxy-Host', os.hostname())
       if config.get('devMode')
         console.log 'FORWARD: ' + req.url
       console.log(logger(req, res))
@@ -268,6 +269,9 @@ Set-up Express with cookie parsing and HSTS.
 
     app = websrv()
     app.use cookieParser()
+
+    if !config.get('devMode')
+      app.disable('x-powered-by');
 
     ONE_YEAR = 31536000000
     app.use helmet.hsts

--- a/drupal-auth-proxy.litcoffee
+++ b/drupal-auth-proxy.litcoffee
@@ -299,6 +299,7 @@ Configure server port & SSL.
     key = config.get('sslKeyPath')
     if fs.existsSync(cert) and fs.existsSync(key)
       options =
+        "secureOptions": require('constants').SSL_OP_NO_TLSv1,
         "cert": fs.readFileSync(cert),
         "key": fs.readFileSync(key)
       https.createServer(options, app).listen(appPort)

--- a/drupal-auth-proxy.litcoffee
+++ b/drupal-auth-proxy.litcoffee
@@ -271,7 +271,7 @@ Set-up Express with cookie parsing and HSTS.
     app.use cookieParser()
 
     if !config.get('devMode')
-      app.disable('x-powered-by');
+      app.disable('x-powered-by')
 
     ONE_YEAR = 31536000000
     app.use helmet.hsts


### PR DESCRIPTION
Disable TLS v1.0 connections.

I ran this locally after setting up self-signed cert and the server rejects tlsv1.0 connections.
```
$> curl -Iv --tlsv1.0 -k https://127.0.0.1:8000/test/auth-proxy
*   Trying 127.0.0.1...
* Connected to 127.0.0.1 (127.0.0.1) port 8000 (#0)
* Server aborted the SSL handshake
* Closing connection 0
curl: (35) Server aborted the SSL handshake
```